### PR TITLE
src: change to use /bin/sh instead of /bin/bash

### DIFF
--- a/main.go
+++ b/main.go
@@ -355,7 +355,7 @@ func killProcess(theProcessType ProcessType, checkAttempts int) error {
 */
 func runPrep(commandString string, interactive bool) (*exec.Cmd, error) {
 	var err error
-	cmd := exec.Command("/bin/bash", "-c", commandString)
+	cmd := exec.Command("/bin/sh", "-c", commandString)
 	ControllerDebug.log("Set workdir:  " + workDir)
 	cmd.Dir = workDir
 	if interactive {
@@ -376,7 +376,7 @@ func runPrep(commandString string, interactive bool) (*exec.Cmd, error) {
 */
 func startProcess(commandString string, theProcessType ProcessType, interactive bool) (*exec.Cmd, error) {
 	var err error
-	cmd := exec.Command("/bin/bash", "-c", commandString)
+	cmd := exec.Command("/bin/sh", "-c", commandString)
 	ControllerDebug.log("Set workdir:  " + workDir)
 	cmd.Dir = workDir
 	if interactive {


### PR DESCRIPTION
Some container runtimes are intentionally constraned (e.g. alpine).
In these cases, the container may not have `/bin/bash` on the system.
This commit modifies the `runPrep` and `startProcess` functions to
use `/bin/sh` instead of `/bin/bash`.

See also: https://github.com/appsody/appsody/pull/695